### PR TITLE
typing_extensions.List -> typing.List

### DIFF
--- a/tests/test_disk_cache/__main__.py
+++ b/tests/test_disk_cache/__main__.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 
-from pathlib import Path
-import tempfile
-from concurrent.futures import Future, ProcessPoolExecutor
-from typing_extensions import List
 import logging
 import secrets
+import tempfile
+from concurrent.futures import Future, ProcessPoolExecutor
+from pathlib import Path
+from typing import List
 
 from tests import (
     HitsAndMisses,


### PR DESCRIPTION
should fix the build issue in the current [0.5.0 conda feedstock build](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1309208&view=logs&j=7b6f2c87-f3a7-5133-8d84-7c03a75d9dfc&t=9eb77fd2-8ddd-5444-8fc0-71cb28dcb736)